### PR TITLE
Add schema and data options to test operator

### DIFF
--- a/airflow_dbt/hooks/dbt_hook.py
+++ b/airflow_dbt/hooks/dbt_hook.py
@@ -39,6 +39,8 @@ class DbtCliHook(BaseHook):
                  dir='.',
                  vars=None,
                  full_refresh=False,
+                 data_test=False,
+                 schema_test=False,
                  models=None,
                  exclude=None,
                  dbt_bin='dbt',
@@ -49,6 +51,8 @@ class DbtCliHook(BaseHook):
         self.target = target
         self.vars = vars
         self.full_refresh = full_refresh
+        self.data_test = data_test
+        self.schema_test = schema_test
         self.models = models
         self.exclude = exclude
         self.dbt_bin = dbt_bin
@@ -91,6 +95,12 @@ class DbtCliHook(BaseHook):
 
         if self.full_refresh:
             dbt_cmd.extend(['--full-refresh'])
+
+        if self.data_test:
+            dbt_cmd.extend(['--data'])
+
+        if self.schema_test:
+            dbt_cmd.extend(['--schema'])
 
         sp = subprocess.Popen(
             dbt_cmd,

--- a/airflow_dbt/operators/dbt_operator.py
+++ b/airflow_dbt/operators/dbt_operator.py
@@ -43,6 +43,8 @@ class DbtBaseOperator(BaseOperator):
                  dbt_bin='dbt',
                  verbose=True,
                  full_refresh=False,
+                 data_test=False,
+                 schema_test=False,
                  *args,
                  **kwargs):
         super(DbtBaseOperator, self).__init__(*args, **kwargs)
@@ -53,6 +55,8 @@ class DbtBaseOperator(BaseOperator):
         self.vars = vars
         self.models = models
         self.full_refresh = full_refresh
+        self.data_test = data_test
+        self.schema_test = schema_test
         self.exclude = exclude
         self.dbt_bin = dbt_bin
         self.verbose = verbose
@@ -65,6 +69,8 @@ class DbtBaseOperator(BaseOperator):
             dir=self.dir,
             vars=self.vars,
             full_refresh=self.full_refresh,
+            data_test=self.data_test,
+            schema_test=self.schema_test,
             models=self.models,
             exclude=self.exclude,
             dbt_bin=self.dbt_bin,


### PR DESCRIPTION
Add parameters needed by DbtTestOperator to allow for --schema and --data switches when running `dbt test`